### PR TITLE
Updated example to also include a backslash

### DIFF
--- a/storyscript/README.md
+++ b/storyscript/README.md
@@ -261,7 +261,8 @@ The Story above is would perform the following operations:
 data = "foobar"
 
 long_string = "Hi Friend,
-This is a long string."
+This is a lo\
+ng string."
 # Hi Friend, This is a long string.
 
 more_data = """


### PR DESCRIPTION
Updated the example to make it more clear that strings are normally joined with a space but not when you add a backslash.