### PR TITLE
Use same date in both examples.

### DIFF
--- a/storyscript/README.md
+++ b/storyscript/README.md
@@ -433,7 +433,7 @@ range = Range from:(date now) to:tomorrow
 
 ```coffeescript
 [bday year, bday month, bday day, bday hour, bday minute, bday second]
-# [2018, 1, 1, 17, 32, 18]
+# [2018, 1, 2, 17, 32, 18]
 
 bday format 'YYYY-mm-dd'
 # 2018-01-02


### PR DESCRIPTION
The example now uses two different dates. This minor patch corrects that.